### PR TITLE
Use platformdirs for platform dependent cache directories

### DIFF
--- a/aircmd/models/base.py
+++ b/aircmd/models/base.py
@@ -5,6 +5,7 @@ import sys
 from typing import Any, Optional, Type
 
 import dagger
+import platformdirs
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings
@@ -30,21 +31,13 @@ class GlobalSettings(BaseSettings):
     LOG_LEVEL: str = Field("WARNING", env="LOG_LEVEL")
     PLATFORM: str = platform.system()
     POETRY_CACHE_DIR: str = Field(
-        default_factory=lambda: (
-            f"{os.path.expanduser('~')}/Library/Caches/pypoetry" if platform.system() == "Darwin"
-            else f"{os.path.expanduser('~')}/AppData/Local/pypoetry/Cache" if platform.system() == "Windows"
-            else f"{os.path.expanduser('~')}/.cache/pypoetry"
-        ),
+        default_factory=lambda: platformdirs.user_cache_dir("pypoetry"),
         env="POETRY_CACHE_DIR"
     )
-    PIP_CACHE_DIR: str = Field(                                                                                                                                          
-         default_factory=lambda: (                                                                                                                                        
-             f"{os.path.expanduser('~')}/Library/Caches/pip" if platform.system() == "Darwin"                                                                             
-             else f"{os.path.expanduser('~')}/AppData/Local/pip/Cache" if platform.system() == "Windows"                                                                  
-             else f"{os.path.expanduser('~')}/.cache/pip"                                                                                                                 
-         ),                                                                                                                                                               
-         env="PIP_CACHE_DIR"                                                                                                                                              
-     ) 
+    PIP_CACHE_DIR: str = Field(
+        default_factory=lambda: platformdirs.user_cache_dir("pip"),
+        env="PIP_CACHE_DIR"
+    )
     # Add new secrets as fields
     SECRET_1: str = Field(..., env="SECRET_1")
     SECRET_2: str = Field(..., env="SECRET_2")


### PR DESCRIPTION
It seems to me using [platformdirs](https://platformdirs.readthedocs.io/en/latest/api.html#cache-directory) should give you the same cache dirs. However if these are to be used in containers, you don't actually want platform dependent dirs.