### PR TITLE
introduce nodejs into gradle image for prettier formatting

### DIFF
--- a/aircmd/actions/environments.py
+++ b/aircmd/actions/environments.py
@@ -361,7 +361,7 @@ def with_gradle(
         client.container()
         .from_("openjdk:17.0.1-jdk-slim")
         .with_exec(["apt-get", "update"])
-        .with_exec(["apt-get", "install", "-y", "curl", "jq", "rsync"])
+        .with_exec(["apt-get", "install", "-y", "curl", "jq", "rsync", "nodejs", "npm"]) # we use prettier in java builds unfortunately
         .with_env_variable("VERSION", settings.DOCKER_VERSION)
         .with_exec(["sh", "-c", "curl -fsSL https://get.docker.com | sh"])
         .with_env_variable("GRADLE_HOME", "/root/.gradle")


### PR DESCRIPTION
This is not ideal at all, but in lieu of formatting in place of prettier we need to do a bit of extra legwork to use something like  https://github.com/jhipster/prettier-java instead. So for now, we unfortunately bake node into the gradle image