### PR TITLE
feat: add authenticated docker client helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
       - name: Run Dagger
+        env: #TODO: Don't use GHA secrets for this
+          SECRET_DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          SECRET_DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          PREFECT_API_URL: "https://prefect.airbyte.com/api"
+          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"
+          _EXPERIMENTAL_DAGGER_RUNNER_HOST: "unix:///var/run/buildkit/buildkitd.sock"
+          DAGGER_CLI_COMMIT: "6ed6264f1c4efbf84d310a104b57ef1bc57d57b0"
         run: |
-          export PREFECT_API_URL="https://prefect.airbyte.com/api"
-          export _EXPERIMENTAL_DAGGER_CLOUD_TOKEN="p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"
-          export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
-          DAGGER_CLI_COMMIT="6ed6264f1c4efbf84d310a104b57ef1bc57d57b0"
-          DAGGER_TMP_BINDIR="/tmp/dagger_${DAGGER_CLI_COMMIT}"
+          export DAGGER_TMP_BINDIR="/tmp/dagger_${DAGGER_CLI_COMMIT}"
           export _EXPERIMENTAL_DAGGER_CLI_BIN="$DAGGER_TMP_BINDIR/dagger"
           if [ ! -f  "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]; then
             mkdir -p "$DAGGER_TMP_BINDIR"

--- a/aircmd/actions/environments.py
+++ b/aircmd/actions/environments.py
@@ -224,7 +224,7 @@ def with_dockerd_service(
         client.container()
         .from_(settings.DOCKER_DIND_IMAGE)
         .with_(load_settings(client, settings))
-        .with_exec(["docker", "login", "-u", "$SECRET_DOCKER_HUB_USERNAME", "-p","$SECRET_DOCKER_HUB_PASSWORD"])
+        .with_exec(["sh", "-c", "docker login -u $SECRET_DOCKER_HUB_USERNAME -p $SECRET_DOCKER_HUB_PASSWORD"])
         .with_mounted_cache(
             "/var/lib/docker",
             client.cache_volume(docker_lib_volume_name),

--- a/aircmd/actions/environments.py
+++ b/aircmd/actions/environments.py
@@ -260,6 +260,35 @@ def with_bound_docker_host(
         .with_mounted_cache("/tmp", client.cache_volume("shared-tmp"))
     )
 
+def with_bound_docker_host_and_authenticated_client(
+    context: PipelineContext,
+    settings: GlobalSettings,
+    client: Client,
+    container: Container,
+) -> Container:
+    """Bind a container to a docker host and authenticate the docker client using the creds specified via settings.
+    Args:
+        context (ConnectorContext): The current connector context.
+        container (Container): The container to bind to the docker host.
+    Returns:
+        Container: The container bound to the docker host.
+    """
+    dockerd = context.dockerd_service
+    assert dockerd is not None
+    docker_hostname = "global-docker-host"
+
+    docker_username = client.set_secret("docker_hub_username", settings.SECRET_DOCKER_HUB_USERNAME.get_secret_value())
+    docker_password = client.set_secret("docker_hub_password", settings.SECRET_DOCKER_HUB_PASSWORD.get_secret_value())
+
+    return (
+        container.with_env_variable("DOCKER_HOST", f"tcp://{docker_hostname}:2375")
+        .with_service_binding(docker_hostname, dockerd)
+        .with_mounted_cache("/tmp", client.cache_volume("shared-tmp"))
+        .with_secret_variable("DOCKER_USERNAME", docker_username)
+        .with_secret_variable("DOCKER_PASSWORD", docker_password)
+        .with_exec(["sh", "-c", "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"])
+    )
+
 
 def with_global_dockerd_service(dagger_client: Client, settings: GlobalSettings) -> Container:
     """Create a container with a docker daemon running.
@@ -386,7 +415,7 @@ def with_gradle(
     )
 
     if bind_to_docker_host:
-        return with_bound_docker_host(context, client, openjdk_with_docker)
+        return with_bound_docker_host_and_authenticated_client(context, settings, client, openjdk_with_docker)
     else:
         return openjdk_with_docker
 

--- a/aircmd/actions/environments.py
+++ b/aircmd/actions/environments.py
@@ -274,8 +274,8 @@ def with_bound_docker_host_and_authenticated_client(
     Returns:
         Container: The container bound to the docker host.
     """
-    docker_username = client.set_secret("docker_hub_username", settings.SECRET_DOCKER_HUB_USERNAME.get_secret_value())
-    docker_password = client.set_secret("docker_hub_password", settings.SECRET_DOCKER_HUB_PASSWORD.get_secret_value())
+    docker_username = client.set_secret("docker_hub_username", settings.SECRET_DOCKER_HUB_USERNAME.get_secret_value()) # type: ignore[union-attr]
+    docker_password = client.set_secret("docker_hub_password", settings.SECRET_DOCKER_HUB_PASSWORD.get_secret_value()) # type: ignore[union-attr]
 
     return (
         with_bound_docker_host(context, client, container)


### PR DESCRIPTION
We want `with_gradle()` to use a dockerd service binding and also perform a `docker login` so that we avoid any rate limits when interacting with docker hub.

This PR adds a new helper called `with_bound_docker_host_and_autenticated_client()`, which extends the provided with container with an authenticated docker client.

Fixes: 
- Calls to `.with_exec()` that want to use ENV var expansion need to wrap the command in a SHELL (e.g. `["sh", "-c", "command $SOMEVAR"]`)
